### PR TITLE
http: Add pathname to baseUrl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# [2.1.1](https://github.com/CESARBR/knot-cloud-sdk-js-authenticator/compare/v2.1.0...v2.1.1)
+
+ ### Bug Fixes
+
+- Add pathname parameter to HTTP component.
+
 # [2.1.0](https://github.com/CESARBR/knot-cloud-sdk-js-authenticator/compare/v2.0.1...v2.1.0)
 
  ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cesarbr/knot-cloud-sdk-js-authenticator",
-	"version": "2.1.0",
+	"version": "2.1.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cesarbr/knot-cloud-sdk-js-authenticator",
-	"version": "2.1.0",
+	"version": "2.1.1",
 	"description": "KNoT Cloud Authenticator library for NodeJS and browser",
 	"main": "./dist/main.js",
 	"module": "./dist/module.mjs",

--- a/src/network/HTTP.js
+++ b/src/network/HTTP.js
@@ -5,6 +5,7 @@ export default class HTTP {
     protocol = 'https',
     hostname = 'api.knot.cloud',
     port = (protocol === 'https') ? 443 : 80,
+    pathname = '',
   }) {
     if ((protocol !== 'http') && (protocol !== 'https')) {
       throw new Error('Invalid protocol: must be either \'https\' or \'http\'');
@@ -13,7 +14,7 @@ export default class HTTP {
       throw new Error('Required field missing: \'hostname\'');
     }
 
-    this.baseUrl = `${protocol}://${hostname}:${port}`;
+    this.baseUrl = `${protocol}://${hostname}:${port}${pathname}`;
     this.header = {
       Accept: 'application/json',
       'Content-Type': 'application/json',


### PR DESCRIPTION
**Describe what this PR introduces:** 

This PR adds support to passing pathname when operating on authenticator API.

**What kind of change does this PR introduce?** (check at least one)

- [X] Bug fix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce any breaking changes?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] Related issues are referenced in the PR (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included

**Testing environment:**

- Operating System/Platform: macOs Darwin - 18.0.0
- Node version: v12.16.2
- Yarn version: 1.16.0

If you have relevant logs, error output and etc, please attach them.

**Other information:**
